### PR TITLE
refactor now/utcnow to output a nushell datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,16 +820,16 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2800e1520bdc966782168a627aa5d1ad92e33b984bf7c7615d31280c83ff14"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "itertools",
  "nu-engine",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "convert_case",
  "proc-macro-error",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "log",
  "nu-glob",
@@ -863,11 +863,11 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.95.1"
+version = "0.96.1"
 
 [[package]]
 name = "nu-parser"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "bytesize",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "dirs",
  "omnipath",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "log",
  "nix",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "interprocess",
  "log",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-engine"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "log",
  "nu-engine",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "bincode",
  "nu-protocol",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-test-support"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "nu-ansi-term",
  "nu-cmd-lang",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "brotli",
  "byte-unit",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "chrono",
  "itertools",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.95.1"
+version = "0.96.1"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1031,6 +1031,7 @@ dependencies = [
  "nu-plugin",
  "nu-plugin-test-support",
  "nu-protocol",
+ "nuon",
 ]
 
 [[package]]
@@ -1065,6 +1066,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "nuon"
+version = "0.96.1"
+dependencies = [
+ "fancy-regex",
+ "nu-engine",
+ "nu-parser",
+ "nu-protocol",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ license = "MIT"
 [dependencies]
 jiff = { version = "0.1.0", features = ["logging", "serde"] }
 # for local development, you can use a path dependency
-nu-plugin = { path = "../nushell/crates/nu-plugin", version = "0.95.1" }
-nu-protocol = { path = "../nushell/crates/nu-protocol", version = "0.95.1", features = ["plugin"] }
+nu-plugin = { path = "../nushell/crates/nu-plugin", version = "0.96.1" }
+nu-protocol = { path = "../nushell/crates/nu-protocol", version = "0.96.1", features = ["plugin"] }
+nuon = { version = "0.96.1", path = "../nushell/crates/nuon" }
 # nu-plugin = "0.95.0"
 # nu-protocol = { version = "0.95.0", features = ["plugin"] }
 
 [dev-dependencies]
-nu-plugin-test-support = { path = "../nushell/crates/nu-plugin-test-support", version = "0.95.1" }
+nu-plugin-test-support = { path = "../nushell/crates/nu-plugin-test-support", version = "0.96.1" }
 # nu-plugin-test-support = { version = "0.95.0" }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,9 +3,11 @@ mod add;
 mod dt;
 mod now;
 mod utcnow;
+mod utils;
 
 // Command structs should be exported here
 pub use add::Add;
 pub use dt::Dt;
 pub use now::Now;
 pub use utcnow::UtcNow;
+// pub use utils::convert_nanos_to_datetime;

--- a/src/commands/now.rs
+++ b/src/commands/now.rs
@@ -1,3 +1,4 @@
+use super::utils::convert_nanos_to_datetime;
 use crate::DtPlugin;
 use jiff::Zoned;
 use nu_plugin::{EngineInterface, EvaluatedCall, SimplePluginCommand};
@@ -21,7 +22,7 @@ impl SimplePluginCommand for Now {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["date", "time"]
+        vec!["date", "time", "current"]
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -35,14 +36,13 @@ impl SimplePluginCommand for Now {
     fn run(
         &self,
         _plugin: &DtPlugin,
-        _engine: &EngineInterface,
+        engine: &EngineInterface,
         call: &EvaluatedCall,
         _input: &Value,
     ) -> Result<Value, LabeledError> {
         let now = Zoned::now();
-        //FIXME: We can't return a Value::date because nushell's Value::Date is based on chrono's DateTime<FixedOffset>
-        // We'll need to add something like Value::Dt that is based on Jiff
-        Ok(Value::string(now.to_string(), call.head))
+        let nanos = now.timestamp().as_nanosecond();
+        convert_nanos_to_datetime(nanos, engine, call.head, false)
     }
 }
 

--- a/src/commands/utcnow.rs
+++ b/src/commands/utcnow.rs
@@ -1,3 +1,4 @@
+use super::utils::convert_nanos_to_datetime;
 use crate::DtPlugin;
 use jiff::Zoned;
 use nu_plugin::{EngineInterface, EvaluatedCall, SimplePluginCommand};
@@ -21,7 +22,7 @@ impl SimplePluginCommand for UtcNow {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["date", "time"]
+        vec!["date", "time", "current"]
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -35,7 +36,7 @@ impl SimplePluginCommand for UtcNow {
     fn run(
         &self,
         _plugin: &DtPlugin,
-        _engine: &EngineInterface,
+        engine: &EngineInterface,
         call: &EvaluatedCall,
         _input: &Value,
     ) -> Result<Value, LabeledError> {
@@ -43,9 +44,8 @@ impl SimplePluginCommand for UtcNow {
         let nowutc = now
             .intz("UTC")
             .map_err(|err| LabeledError::new(err.to_string()))?;
-        //FIXME: We can't return a Value::date because nushell's Value::Date is based on chrono's DateTime<FixedOffset>
-        // We'll need to add something like Value::Dt that is based on Jiff
-        Ok(Value::string(nowutc.to_string(), call.head))
+        let nanos = nowutc.timestamp().as_nanosecond();
+        convert_nanos_to_datetime(nanos, engine, call.head, true)
     }
 }
 

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -1,0 +1,32 @@
+use nu_plugin::{EngineInterface, EvaluatedCall};
+use nu_protocol::{IntoSpanned, LabeledError, PipelineData, Span, Value};
+
+// This is kind of a hack to convert jiff produced nanoseconds to Value::Date by
+// converting nanos with the 'into datetime' nushell command
+pub fn convert_nanos_to_datetime(
+    nanos: i128,
+    engine: &EngineInterface,
+    span: Span,
+    utc: bool,
+) -> Result<Value, LabeledError> {
+    let Some(decl_id) = engine.find_decl("into datetime")? else {
+        return Err(LabeledError::new(
+            "Could not find 'into datetime' declaration".to_string(),
+        ));
+    };
+    let into_datetime = engine.call_decl(
+        decl_id,
+        if utc {
+            EvaluatedCall::new(span)
+                .with_named("timezone".into_spanned(span), Value::string("UTC", span))
+        } else {
+            EvaluatedCall::new(span)
+                .with_named("timezone".into_spanned(span), Value::string("LOCAL", span))
+        },
+        PipelineData::Value(Value::int(nanos as i64, span), None),
+        true,
+        false,
+    )?;
+    let datetime = into_datetime.into_value(span)?;
+    Ok(datetime)
+}


### PR DESCRIPTION
This is kind of a hack around nushell not supporting the jiff date time crate. I convert the datetime to nanoseconds and then call into datetime -l or -u for translating to a nushell datetime value.