### PR TITLE
refactor + add dt part

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "itertools",
  "nu-engine",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "convert_case",
  "proc-macro-error",
@@ -852,22 +852,23 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "log",
  "nu-glob",
  "nu-path",
  "nu-protocol",
  "nu-utils",
+ "terminal_size",
 ]
 
 [[package]]
 name = "nu-glob"
-version = "0.96.1"
+version = "0.96.2"
 
 [[package]]
 name = "nu-parser"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "bytesize",
  "chrono",
@@ -882,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "dirs",
  "omnipath",
@@ -891,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "log",
  "nix",
@@ -905,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "interprocess",
  "log",
@@ -919,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-engine"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "log",
  "nu-engine",
@@ -934,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "bincode",
  "nu-protocol",
@@ -946,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-test-support"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "nu-ansi-term",
  "nu-cmd-lang",
@@ -962,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "brotli",
  "byte-unit",
@@ -992,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "chrono",
  "itertools",
@@ -1010,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1070,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "nuon"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "fancy-regex",
  "nu-engine",
@@ -1491,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a600f795d0894cda22235b44eea4b85c2a35b405f65523645ac8e35b306817a"
+checksum = "d253e54681d4be0161e965db57974ae642a0b6aaeb18a999424c4dab062be8c5"
 dependencies = [
  "const_format",
  "is_debug",

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ This is not meant to be an exhaustive list of requirments but enough to get star
 
 - use [jiff](https://github.com/BurntSushi/jiff) crate and [docs](https://docs.rs/jiff/latest/jiff/)
 - date math
-    - `dt add` duration
-    - `dt sub` duration
-    - `dt sub` date
-    - `dt sub` time
-    - `dt sub` datetime
+    - [x] `dt add` duration
+    - [ ] `dt sub` duration
+    - [ ] `dt sub` date
+    - [ ] `dt sub` time
+    - [ ] `dt sub` datetime
     - ability to express durations in a similar way that nushell does or better. specifically better means the ability to return durations in these representations while accounting for leap year math so that any date math operation is accurate. Note: it's known that leap-seconds do not exist in jiff (yet) so it doesn't have to be that accurate but more accurate than nushell currently is without having to average days for months or years.
         - years
         - months
@@ -46,9 +46,9 @@ This is not meant to be an exhaustive list of requirments but enough to get star
         - milliseconds
         - microseconds
         - nanoseconds
-    - `dt date`
-    - `dt utcdate`
-    - `dt part`
+    - [x] `dt now`
+    - [x] `dt utcnow`
+    - [x] `dt part`
 
     - should date math be more [sql like](https://www.sqlshack.com/how-to-add-or-subtract-dates-in-sql-server/) where you have a `date add` and `date diff` function that takes a positive or negative number and a unit?
         - [dt add](https://www.w3schools.com/sql/func_sqlserver_dateadd.asp) SQL: `SELECT DATEADD(year, 1, '2017/08/25') AS DateAdd;`
@@ -87,17 +87,17 @@ These could take a date or date time piped in.
 
 ```nushell
 # dt add (add a duration to a date)
-2017-08-25 | dt add 1day
+'2017-08-25' | dt add 1day
 # dt sub (subtract a duration from a date)
-2017-08-25 | dt sub 1day
+'2017-08-25' | dt sub 1day
 # dt sub (subtract two dates)
-2017-08-25 | dt sub 2024-07-01
+'2017-08-25' | dt sub 2024-07-01
 # dt sub (subtract time from a date)
-2017-08-25 | dt sub 00:02:00
+'2017-08-25' | dt sub 00:02:00
 # dt sub (subtrace datetime from a date)
-2017-08-25 | dt sub 2024-07-01T00:02:00
+'2017-08-25' | dt sub 2024-07-01T00:02:00
 # dt part (get the part of the current datetime)
-2017-08-25 | dt part year
+'2017-08-25' | dt part year
 # dt now (get the current local datetime)
 dt now
 # dt utcnow (get the current utc datetime)
@@ -133,15 +133,15 @@ iso_week, isowk, isoww = ISO week
 
 ```nushell
 # dt add (add 1 year)
-2017-08-25 | dt add --unit year --amount 1
+'2017-08-25' | dt add --unit year --amount 1
 # dt add (subtract 1 year)
-2017-08-25 | dt add --unit year --amount -1
+'2017-08-25' | dt add --unit year --amount -1
 # dt diff (subtract two dates)
-2017-08-25 | dt diff --unit year --date 2011-08-25
+'2017-08-25' | dt diff --unit year --date 2011-08-25
 # dt part (get the year part of the date/datetime passed in)
-2017-08-25 | dt part --unit year (may not need the --unit here but leaving to be consistent for now)
-# dt date (get the current local datetime)
-dt date
-# dt utcdate (get the current utc datetime)
-dt utcdate
+'2017-08-25' | dt part --unit year (may not need the --unit here but leaving to be consistent for now)
+# dt now (get the current local datetime)
+dt now
+# dt utcnow (get the current utc datetime)
+dt utcnow
 ```

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,5 +1,5 @@
+use super::utils::parse_datetime_string_add_nanos;
 use crate::DtPlugin;
-use jiff::{fmt::temporal::DateTimeParser, ToSpan, Zoned};
 use nu_plugin::{EngineInterface, EvaluatedCall, SimplePluginCommand};
 use nu_protocol::{Category, Example, LabeledError, Signature, SyntaxShape, Value};
 
@@ -80,33 +80,7 @@ impl SimplePluginCommand for Add {
             Value::String { val, .. } => {
                 // eprintln!("String: {:?}", val);
 
-                let cur_date_time_zone = Zoned::now();
-                let tz = cur_date_time_zone.time_zone().clone();
-                // let tz_name = tz.iana_name().unwrap_or_default();
-                // let dt_with_tz = format!("{}[{}]", val, tz_name);
-
-                // A parser can be created in a const context.
-                static PARSER: DateTimeParser = DateTimeParser::new();
-                // let date = PARSER
-                //     .parse_zoned(dt_with_tz)
-                //     .map_err(|err| LabeledError::new(err.to_string()))?;
-                // let zdt = date.with_time_zone(tz);
-
-                // Parse a civil datetime string into a civil::DateTime.
-                let date = PARSER
-                    .parse_datetime(val)
-                    .map_err(|err| LabeledError::new(err.to_string()))?;
-                // eprintln!("Date: {:?}", date);
-
-                let date_plus_duration = date
-                    .checked_add(duration_nanos.nanoseconds())
-                    .map_err(|err| LabeledError::new(err.to_string()))?;
-                // eprintln!("Date + Duration: {:?}", date_plus_duration);
-
-                let zdt = date_plus_duration
-                    .to_zoned(tz)
-                    .map_err(|err| LabeledError::new(err.to_string()))?;
-                // eprintln!("Zoned: {:?}", zdt);
+                let zdt = parse_datetime_string_add_nanos(val, duration_nanos)?;
                 Ok(Value::string(zdt.to_string(), call.head))
             }
             _ => return Err(LabeledError::new("Expected a date or datetime".to_string())),

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -73,9 +73,9 @@ impl SimplePluginCommand for Add {
         match input {
             Value::Date { val, .. } => {
                 eprintln!("Date: {:?}", val);
-                return Err(LabeledError::new(
+                Err(LabeledError::new(
                     "Expected a date or datetime string".to_string(),
-                ));
+                ))
             }
             Value::String { val, .. } => {
                 // eprintln!("String: {:?}", val);
@@ -83,7 +83,7 @@ impl SimplePluginCommand for Add {
                 let zdt = parse_datetime_string_add_nanos(val, duration_nanos)?;
                 Ok(Value::string(zdt.to_string(), call.head))
             }
-            _ => return Err(LabeledError::new("Expected a date or datetime".to_string())),
+            _ => Err(LabeledError::new("Expected a date or datetime".to_string())),
         }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@
 mod add;
 mod dt;
 mod now;
+mod part;
 mod utcnow;
 mod utils;
 
@@ -9,5 +10,6 @@ mod utils;
 pub use add::Add;
 pub use dt::Dt;
 pub use now::Now;
+pub use part::Part;
 pub use utcnow::UtcNow;
 // pub use utils::convert_nanos_to_datetime;

--- a/src/commands/part.rs
+++ b/src/commands/part.rs
@@ -81,13 +81,13 @@ impl SimplePluginCommand for Part {
         } else {
             let unit: Vec<String> = call.rest(0)?;
             if unit.is_empty() {
-                return Err(LabeledError::new(
+                Err(LabeledError::new(
                     "please supply a unit name to extract from a date/datetime.",
-                ));
+                ))
             } else if unit.len() > 1 {
-                return Err(LabeledError::new(
+                Err(LabeledError::new(
                     "please supply only one unit name to extract from a date/datetime.",
-                ));
+                ))
             } else {
                 let datetime = match input {
                     Value::Date { val, .. } => {
@@ -98,8 +98,7 @@ impl SimplePluginCommand for Part {
                     }
                     Value::String { val, .. } => {
                         // eprintln!("Zoned: {:?}", zdt);
-                        let zdt = parse_datetime_string(val)?;
-                        zdt
+                        parse_datetime_string(val)?
                     }
                     _ => return Err(LabeledError::new("Expected a date or datetime".to_string())),
                 };
@@ -117,9 +116,9 @@ impl SimplePluginCommand for Part {
                     "hour" | "hh" => datetime.hour().into(),
                     "minute" | "mi" | "n" => datetime.minute().into(),
                     "second" | "ss" | "s" => datetime.second().into(),
-                    "millisecond" | "ms" => datetime.millisecond().into(),
-                    "microsecond" | "mcs" => datetime.microsecond().into(),
-                    "nanosecond" | "ns" => datetime.nanosecond().into(),
+                    "millisecond" | "ms" => datetime.millisecond(),
+                    "microsecond" | "mcs" => datetime.microsecond(),
+                    "nanosecond" | "ns" => datetime.nanosecond(),
                     // TODO: Fix this
                     "tzoffset" | "tz" => datetime.offset().seconds().try_into().unwrap(),
                     // TODO: Fix this

--- a/src/commands/part.rs
+++ b/src/commands/part.rs
@@ -1,0 +1,137 @@
+use super::utils::parse_datetime_string;
+use crate::DtPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, SimplePluginCommand};
+use nu_protocol::{record, Category, Example, LabeledError, Signature, SyntaxShape, Value};
+
+pub struct Part;
+
+impl SimplePluginCommand for Part {
+    type Plugin = DtPlugin;
+
+    fn name(&self) -> &str {
+        "dt part"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .rest(
+                "unit",
+                SyntaxShape::String,
+                "Unit name to extract from a date/datetime.",
+            )
+            .switch(
+                "list-abbreviations",
+                "List the unit name abbreviations",
+                Some('l'),
+            )
+            .category(Category::Date)
+    }
+
+    fn usage(&self) -> &str {
+        "Return the specified part of a date and time provided"
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                example: "'2017-08-25' | dt part yy",
+                description: "Return the year part of the provided date",
+                result: Some(Value::test_int(2017)),
+            },
+            Example {
+                example: "'2017-08-25T12:00:00' | dt part hh",
+                description: "Return the hour part of the provided datetime",
+                result: Some(Value::test_int(12)),
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["date", "time"]
+    }
+
+    fn run(
+        &self,
+        _plugin: &DtPlugin,
+        _engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: &Value,
+    ) -> Result<Value, LabeledError> {
+        let list = call.has_flag("list-abbreviations")?;
+        if list {
+            let rec = record! {
+              "year" => Value::test_string("year, yyyy, yy"),
+              "quarter" => Value::test_string("quarter, qq, q"),
+              "month" => Value::test_string("month, mm, m"),
+              "dayofyear" => Value::test_string("dayofyear, dy, y"),
+              "day" => Value::test_string("day, dd, d"),
+              "week" => Value::test_string("week, ww, wk"),
+              "weekday" => Value::test_string("weekday, dw, w"),
+              "hour" => Value::test_string("hour, hh"),
+              "minute" => Value::test_string("minute, mi, n"),
+              "second" => Value::test_string("second, ss, s"),
+              "millisecond" => Value::test_string("millisecond, ms"),
+              "microsecond" => Value::test_string("microsecond, mcs"),
+              "nanosecond" => Value::test_string("nanosecond, ns"),
+              "tzoffset" => Value::test_string("tzoffset, tz"),
+              "iso_week" => Value::test_string("iso_week, isowk, isoww")
+            };
+
+            Ok(Value::record(rec, call.head))
+        } else {
+            let unit: Vec<String> = call.rest(0)?;
+            if unit.is_empty() {
+                return Err(LabeledError::new(
+                    "please supply a unit name to extract from a date/datetime.",
+                ));
+            } else if unit.len() > 1 {
+                return Err(LabeledError::new(
+                    "please supply only one unit name to extract from a date/datetime.",
+                ));
+            } else {
+                let datetime = match input {
+                    Value::Date { val, .. } => {
+                        eprintln!("Date: {:?}", val);
+                        return Err(LabeledError::new(
+                            "Expected a date or datetime string".to_string(),
+                        ));
+                    }
+                    Value::String { val, .. } => {
+                        // eprintln!("Zoned: {:?}", zdt);
+                        let zdt = parse_datetime_string(val)?;
+                        zdt
+                    }
+                    _ => return Err(LabeledError::new("Expected a date or datetime".to_string())),
+                };
+
+                let date = match unit[0].as_ref() {
+                    "year" | "yyyy" | "yy" => datetime.year(),
+                    // TODO: Fix this
+                    "quarter" | "qq" | "q" => 1,
+                    "month" | "mm" | "m" => datetime.month().into(),
+                    "dayofyear" | "dy" | "y" => datetime.day_of_year(),
+                    "day" | "dd" | "d" => datetime.day().into(),
+                    // TODO: Fix this
+                    "week" | "ww" | "wk" => 1,
+                    "weekday" | "dw" | "w" => datetime.weekday().to_sunday_zero_offset().into(),
+                    "hour" | "hh" => datetime.hour().into(),
+                    "minute" | "mi" | "n" => datetime.minute().into(),
+                    "second" | "ss" | "s" => datetime.second().into(),
+                    "millisecond" | "ms" => datetime.millisecond().into(),
+                    "microsecond" | "mcs" => datetime.microsecond().into(),
+                    "nanosecond" | "ns" => datetime.nanosecond().into(),
+                    // TODO: Fix this
+                    "tzoffset" | "tz" => datetime.offset().seconds().try_into().unwrap(),
+                    // TODO: Fix this
+                    "iso_week" | "isowk" | "isoww" => 1,
+                    _ => {
+                        return Err(LabeledError::new(
+                            "please supply a valid unit name to extract from a date/datetime. see dt part --list for list of abbreviations.",
+                        ))
+                    }
+                };
+                Ok(Value::int(date.into(), call.head))
+            }
+        }
+    }
+}

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -1,3 +1,4 @@
+use jiff::{fmt::temporal::DateTimeParser, ToSpan, Zoned};
 use nu_plugin::{EngineInterface, EvaluatedCall};
 use nu_protocol::{IntoSpanned, LabeledError, PipelineData, Span, Value};
 
@@ -29,4 +30,54 @@ pub fn convert_nanos_to_datetime(
     )?;
     let datetime = into_datetime.into_value(span)?;
     Ok(datetime)
+}
+
+// Parse a string into a jiff datetime
+pub fn parse_datetime_string(s: &str) -> Result<Zoned, LabeledError> {
+    // current date time and time zone
+    let cur_date_time_zone = Zoned::now();
+    let tz = cur_date_time_zone.time_zone().clone();
+
+    // A parser can be created in a const context.
+    static PARSER: DateTimeParser = DateTimeParser::new();
+    // Parse a civil datetime string into a civil::DateTime.
+    let date_time = PARSER
+        .parse_datetime(s)
+        .map_err(|err| LabeledError::new(err.to_string()))?;
+    // eprintln!("Date: {:?}", date);
+
+    let zdt = date_time
+        .to_zoned(tz)
+        .map_err(|err| LabeledError::new(err.to_string()))?;
+
+    Ok(zdt)
+}
+
+pub fn parse_datetime_string_add_nanos(
+    s: &str,
+    duration_nanos: i64,
+) -> Result<Zoned, LabeledError> {
+    let cur_date_time_zone = Zoned::now();
+    let tz = cur_date_time_zone.time_zone().clone();
+
+    // A parser can be created in a const context.
+    static PARSER: DateTimeParser = DateTimeParser::new();
+
+    // Parse a civil datetime string into a civil::DateTime.
+    let date = PARSER
+        .parse_datetime(s)
+        .map_err(|err| LabeledError::new(err.to_string()))?;
+    // eprintln!("Date: {:?}", date);
+
+    let date_plus_duration = date
+        .checked_add(duration_nanos.nanoseconds())
+        .map_err(|err| LabeledError::new(err.to_string()))?;
+    // eprintln!("Date + Duration: {:?}", date_plus_duration);
+
+    let zdt = date_plus_duration
+        .to_zoned(tz)
+        .map_err(|err| LabeledError::new(err.to_string()))?;
+    // eprintln!("Zoned: {:?}", zdt);
+
+    Ok(zdt)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use nu_plugin::{Plugin, PluginCommand};
 
 pub use commands::Add;
 pub use commands::Now;
+pub use commands::Part;
 pub use commands::UtcNow;
 
 pub struct DtPlugin;
@@ -23,6 +24,7 @@ impl Plugin for DtPlugin {
             Box::new(Now),
             Box::new(UtcNow),
             Box::new(Dt),
+            Box::new(Part),
         ]
     }
 }


### PR DESCRIPTION
Has some rough edges and not all the abbreviations work.
```nushell
❯ dt part --list-abbreviations
╭─────────────┬────────────────────────╮
│ year        │ year, yyyy, yy         │
│ quarter     │ quarter, qq, q         │
│ month       │ month, mm, m           │
│ dayofyear   │ dayofyear, dy, y       │
│ day         │ day, dd, d             │
│ week        │ week, ww, wk           │
│ weekday     │ weekday, dw, w         │
│ hour        │ hour, hh               │
│ minute      │ minute, mi, n          │
│ second      │ second, ss, s          │
│ millisecond │ millisecond, ms        │
│ microsecond │ microsecond, mcs       │
│ nanosecond  │ nanosecond, ns         │
│ tzoffset    │ tzoffset, tz           │
│ iso_week    │ iso_week, isowk, isoww │
╰─────────────┴────────────────────────╯
❯ '2017-08-25T12:00:00' | dt part mm
8
❯ '2017-08-25T12:00:00' | dt part d
25
```