### PR TITLE
change add to use jiff durations, update test, add ai generated tests

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -178,18 +178,18 @@ fn calculate_date_diff(
     // convert piped_in_input into a jiff::Zoned
     let mut zoned_input_datetime = match piped_in_input {
         Value::Date { val, .. } => {
-            eprintln!("Date rfc3339: {:?}", &val.to_rfc3339());
-            parse_datetime_string_add_nanos_optionally(&val.to_rfc3339(), None, piped_span)?
+            // eprintln!("Date rfc3339: {:?}", &val.to_rfc3339());
+            parse_datetime_string_add_nanos_optionally(&val.to_rfc3339(), None, piped_span, None)?
         }
         Value::String { val, .. } => {
-            parse_datetime_string_add_nanos_optionally(val, None, piped_span)?
+            parse_datetime_string_add_nanos_optionally(val, None, piped_span, None)?
         }
         _ => return Err(LabeledError::new("Expected a date or datetime".to_string())),
     };
 
     // convert parameter_datetime into a jiff::Zoned
     let mut zoned_parameter_datetime =
-        parse_datetime_string_add_nanos_optionally(&parameter_datetime, None, param_span)?;
+        parse_datetime_string_add_nanos_optionally(&parameter_datetime, None, param_span, None)?;
 
     // Check to see if biggest_unit_opt and smallest_unit_opt are both provided or as_unit_opt is provided
     if (biggest_unit_opt.is_some() || smallest_unit_opt.is_some()) && as_unit_opt.is_some() {
@@ -199,9 +199,9 @@ fn calculate_date_diff(
     }
 
     if zoned_input_datetime.time_zone() == zoned_parameter_datetime.time_zone() {
-        eprintln!("Timezones are the same");
+        // eprintln!("Timezones are the same");
     } else {
-        eprintln!("Timezones are different");
+        // eprintln!("Timezones are different");
         // let zdt_input_ts = zoned_input_datetime.timestamp();
         // let zdt_parameter_ts = zoned_parameter_datetime.timestamp();
         // eprintln!(

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -59,11 +59,11 @@ impl SimplePluginCommand for DtFormat {
         let datetime = match input {
             Value::Date { val, .. } => {
                 // so much easier just to output chrono as rfc 3339 and let jiff parse it
-                parse_datetime_string_add_nanos_optionally(&val.to_rfc3339(), None, span)?
+                parse_datetime_string_add_nanos_optionally(&val.to_rfc3339(), None, span, None)?
             }
             Value::String { val, .. } => {
                 // eprintln!("String: {:?}", val);
-                parse_datetime_string_add_nanos_optionally(val, None, span)?
+                parse_datetime_string_add_nanos_optionally(val, None, span, None)?
             }
             _ => {
                 return Err(LabeledError::new(

--- a/src/commands/part.rs
+++ b/src/commands/part.rs
@@ -50,12 +50,12 @@ impl SimplePluginCommand for DtPart {
                 example: "(date now) | dt part mon",
                 description:
                     "Return the month part of the provided nushell datetime from the date command",
-                result: Some(Value::test_int(8)),
+                result: None,
             },
             Example {
                 example: "(dt now) | dt part wk",
                 description: "Return the week part of the provided datetime from the dt command",
-                result: Some(Value::test_int(8)),
+                result: None,
             },
         ]
     }
@@ -104,11 +104,16 @@ impl SimplePluginCommand for DtPart {
 
                         // so much easier just to output chrono as rfc 3339 and let jiff parse it
 
-                        parse_datetime_string_add_nanos_optionally(&val.to_rfc3339(), None, span)?
+                        parse_datetime_string_add_nanos_optionally(
+                            &val.to_rfc3339(),
+                            None,
+                            span,
+                            None,
+                        )?
                     }
                     Value::String { val, .. } => {
                         // eprintln!("Zoned: {:?}", zdt);
-                        parse_datetime_string_add_nanos_optionally(val, None, span)?
+                        parse_datetime_string_add_nanos_optionally(val, None, span, None)?
                     }
                     _ => return Err(LabeledError::new("Expected a date or datetime".to_string())),
                 };

--- a/src/commands/to.rs
+++ b/src/commands/to.rs
@@ -31,7 +31,12 @@ impl SimplePluginCommand for DtTo {
         vec![Example {
             example: "'07/09/24' | dt to",
             description: "Print the piped in date or datetime in various standard formats",
-            result: None,
+            result: Some(Value::test_record(record! {
+                "rfc9557" => Value::test_string("2024-07-09T00:00:00-05:00[America/Chicago]"),
+                "rfc3339" => Value::test_string("2024-07-09T05:00:00Z"),
+                "rfc2822" => Value::test_string("Tue, 9 Jul 2024 00:00:00 -0500"),
+                "iso8601" => Value::test_string("2024-07-09T00:00:00-05:00"),
+            })),
         }]
     }
 
@@ -52,11 +57,11 @@ impl SimplePluginCommand for DtTo {
         let datetime = match input {
             Value::Date { val, .. } => {
                 // so much easier just to output chrono as rfc 3339 and let jiff parse it
-                parse_datetime_string_add_nanos_optionally(&val.to_rfc3339(), None, span)?
+                parse_datetime_string_add_nanos_optionally(&val.to_rfc3339(), None, span, None)?
             }
             Value::String { val, .. } => {
                 // eprintln!("String: {:?}", val);
-                parse_datetime_string_add_nanos_optionally(val, None, span)?
+                parse_datetime_string_add_nanos_optionally(val, None, span, None)?
             }
             _ => {
                 return Err(LabeledError::new(


### PR DESCRIPTION
- Allow `add` to use jiff durations instead of nushell durations
- Better help messages in `add`
- Cleanup some comments
- Check if only YYYY-MM-DD was passed in
- Comment out or silence eprintln!()'s
- update `to` test
- update `part` tests
- move things around in `utils::parse_datetime_string_add_nanos_optionally` for better parsing
- add a few ai generated tests to `parse_datetime_string_add_nanos_optionally`